### PR TITLE
增加了脚本结束时destroy销毁dubbo连接的方法和代码

### DIFF
--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/gui/DubboCommonPanel.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/gui/DubboCommonPanel.java
@@ -555,11 +555,11 @@ public class DubboCommonPanel {
         modelAttachment.setDataVector(null, columnNamesAttachment);
     }
 
-    private List<MethodArgument> getMethodArgsData(Vector<Vector<String>> data) {
+    private List<MethodArgument> getMethodArgsData(Vector<Vector> data) {
         List<MethodArgument> params = new ArrayList<MethodArgument>();
         if (!data.isEmpty()) {
             //处理参数
-            Iterator<Vector<String>> it = data.iterator();
+            Iterator<Vector> it = data.iterator();
             while(it.hasNext()) {
                 Vector<String> param = it.next();
                 if (!param.isEmpty()) {

--- a/src/main/java/io/github/ningyu/jmeter/plugin/util/Constants.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/util/Constants.java
@@ -102,10 +102,15 @@ public class Constants {
 	public static final String DEFAULT_CLUSTER = "failfast";
 	public static final String DEFAULT_CONNECTIONS = "100";
 
-	//冗余配置元件中的address、protocols、group,用于在sample gui获取配置元件中的默认值
+    //Jmeter元素名称
+    public static final String JMETER_TESTELEMENT_NAME = "TestElement.name";
+
+    //冗余配置元件中的address、protocols、group,用于在sample gui获取配置元件中的默认值
     public static String DEFAULT_PANEL_ADDRESS = "";
     public static String DEFAULT_PANEL_PROTOCOLS = "";
     public static String DEFAULT_PANEL_GROUP = "";
+
+
 
     public static final void redundancy(TestElement element) {
         DEFAULT_PANEL_ADDRESS = Constants.getAddress(element);
@@ -565,6 +570,9 @@ public class Constants {
      */
     public static String referenceConfigToString(TestElement element){
         StringBuilder sb = new StringBuilder();
+
+        sb.append(element.getPropertyAsString(JMETER_TESTELEMENT_NAME));
+
         String protocol = getRegistryProtocol(element);
         sb.append(protocol);
 

--- a/src/main/java/io/github/ningyu/jmeter/plugin/util/Constants.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/util/Constants.java
@@ -559,4 +559,84 @@ public class Constants {
         }
     }
 
+    /**
+     * 为了唯一化一个testElement中的referenceConfig，将其中的内容做了字符串处理。
+     * 便于作为key，因为仅仅使用其中的某几项是不足以唯一化的。
+     */
+    public static String referenceConfigToString(TestElement element){
+        StringBuilder sb = new StringBuilder();
+        String protocol = getRegistryProtocol(element);
+        sb.append(protocol);
+
+        String registryGroup = getRegistryGroup(element);
+        sb.append(registryGroup);
+
+        String registryUserName = getRegistryUserName(element);
+        sb.append(registryUserName);
+
+        String registryPassword = getRegistryPassword(element);
+        sb.append(registryPassword);
+
+        String registryTimeout = getRegistryTimeout(element);
+        sb.append(registryTimeout);
+
+        String configCenterProtocol = getConfigCenterProtocol(element);
+        sb.append(configCenterProtocol);
+
+        String configCenterGroup = getConfigCenterGroup(element);
+        sb.append(configCenterGroup);
+
+        String configCenterNamespace = getConfigCenterNamespace(element);
+        sb.append(configCenterNamespace);
+
+        String configCenterUserName = getConfigCenterUserName(element);
+        sb.append(configCenterUserName);
+
+        String configCenterPassword = getConfigCenterPassword(element);
+        sb.append(configCenterPassword);
+
+        String configCenterAddress = getConfigCenterAddress(element);
+        sb.append(configCenterAddress);
+
+        String configCenterTimeout = getConfigCenterTimeout(element);
+        sb.append(configCenterTimeout);
+
+        String rpcProtocol = getRpcProtocol(element);
+        sb.append(rpcProtocol);
+
+        String address = getAddress(element);
+        sb.append(address);
+
+        String timeout = getTimeout(element);
+        sb.append(timeout);
+
+        String version = getVersion(element);
+        sb.append(version);
+
+        String retries = getRetries(element);
+        sb.append(retries);
+
+        String cluster = getCluster(element);
+        sb.append(cluster);
+
+        String group = getGroup(element);
+        sb.append(group);
+
+        String connections = getConnections(element);
+        sb.append(connections);
+
+        String loadbalance = getLoadbalance(element);
+        sb.append(loadbalance);
+
+        String async = getAsync(element);
+        sb.append(async);
+
+        String anInterface = getInterface(element);
+        sb.append(anInterface);
+
+        String method = getMethod(element);
+        sb.append(method);
+
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

看到源码中的TODO项，增加了脚本结束时destroy销毁dubbo连接的方法。

## Brief changelog

- 核心是新增继承了Jmeter的脚本生命周期监听接口，其中两个方法是有效的，分别是testStarted()和testEnded()，而我要做的就是把销毁链接的代码放入到testEnded()中。是脚本自动或者手动停止之后，会调用到这个方法，这个方法会根据testElement的个数被调用多次。
- 本身看到源码中的invoke已经使用了dubbo自带的缓存ReferenceConfigCache，所以虽然源码中每次请求都会new一个新的reference，但是由于address是一样的，缓存是能重复利用的，所以并没有让连接轻易的泄露。而我销毁连接也是需要从ReferenceConfigCache中找到对应的连接销毁即可。
- 怎么从ReferenceConfigCache找到需要的链接需要增加逻辑，其实由于Jmeter的设计就是单进程，单脚本执行的，那么根据address来定位缓存是没啥问题的，但是也不排除有些平台是支持单进程多脚本执行，那么仅仅根据address来定位缓存有点儿不够，所以使用了所有的配置项的相加的字符串来锁定定位。这里没有参考reference自带的toString方法，主要是生成key使用，简单高效即可。
- cache.destroyAll();由于我们做了更细粒度的缓存的定位区分，所以这里把所有的链接干掉即可。

## Verifying this change

- 本地做了测试，本地的链接是能够被干掉的。
- 测试包括：干掉连接测试。
- 一个脚本，包含内容完全相同的dubbo Sample的测试。
- 一个脚本，包含内容不相同的dubbo Sample的测试。
- 一个脚本，包含内容完全相同的dubbo Sample，但是循环有先后顺序的测试。

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/dubbo/jmeter-plugins-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
