### PR TITLE
Bugfix service reuse for 2.7.4

### DIFF
--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
@@ -73,7 +73,7 @@ public class DubboSample extends AbstractSampler implements Interruptible {
      * Construct request data
      */
     private String getSampleData() {
-//        log.info("sample中的实例id"+this.toString()+",element名称"+this.getName());
+        log.info("sample中的实例id"+this.toString()+",element名称"+this.getName());
     	StringBuilder sb = new StringBuilder();
         sb.append("Registry Protocol: ").append(Constants.getRegistryProtocol(this)).append("\n");
         sb.append("Address: ").append(Constants.getAddress(this)).append("\n");

--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
@@ -73,7 +73,7 @@ public class DubboSample extends AbstractSampler implements Interruptible {
      * Construct request data
      */
     private String getSampleData() {
-        log.info("sample中的实例id"+this.toString()+",element名称"+this.getName());
+//        log.info("sample中的实例id"+this.toString()+",element名称"+this.getName());
     	StringBuilder sb = new StringBuilder();
         sb.append("Registry Protocol: ").append(Constants.getRegistryProtocol(this)).append("\n");
         sb.append("Address: ").append(Constants.getAddress(this)).append("\n");


### PR DESCRIPTION
## What is the purpose of the change

高并发压测场景下存在性能问题：

1. 每次调用sample时，DubboSample中ReferenceConfig重复创建带来的额外开销；
2. 每次调用sample时，ReferenceConfigCache获取ReferenceConfig，再通过ReferenceConfig的get方法重复获取Service实例带来额外开销。
3. 2.7.x版本Dubbo中，ReferenceConfig的get为synchronize方法，并发场景下存在锁竞争问题，导致发压端发压吞吐无法提升。


## Brief changelog

1. Cache and reuse dubbo service.
dubbo service实例通过静态变量缓存，并在每次调用sample时进行复用，避免重复get带来的锁竞争问题
2. Initialize static dubbo service object when null.

## Verifying this change

在单肉鸡20并发场景下，修改前后的吞吐量对比如下：

![image](https://user-images.githubusercontent.com/23240741/206446404-e9390008-2ef3-4ba9-9f07-dec459eebe6e.png)

